### PR TITLE
Change example defaults for linearize

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -1,11 +1,11 @@
-# bitcoind RPC settings (linearize-hashes)
+# vertcoind RPC settings (linearize-hashes)
 rpcuser=someuser
 rpcpassword=somepassword
-#datadir=~/.bitcoin
+#datadir=~/.vertcoin
 host=127.0.0.1
 
 #mainnet default
-port=8332
+port=5888
 
 #testnet default
 #port=18332
@@ -14,14 +14,14 @@ port=8332
 #port=18443
 
 # bootstrap.dat hashlist settings (linearize-hashes)
-max_height=313000
+max_height=857621
 
 # bootstrap.dat input/output settings (linearize-data)
 
 # mainnet
-netmagic=f9beb4d9
-genesis=000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-input=/home/example/.bitcoin/blocks
+netmagic=fabfb5da
+genesis=9249c198d4b1ca38bb92a740d6557df80e746108384552509225e7825556ebdf
+input=/home/example/.vertcoin/blocks
 
 # testnet
 #netmagic=0b110907


### PR DESCRIPTION
This changes the defaults in example-linearize.cfg so that they work with vertcoin. This tool is used to generate bootstrap.dat and these changes should make that process easier for the next person who wants to do so. 