### PR TITLE
Add a command line switch to skip chain of work verification on startup

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -363,6 +363,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-sysperms", _("Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)"));
 #endif
     strUsage += HelpMessageOpt("-txindex", strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"), DEFAULT_TXINDEX));
+    strUsage += HelpMessageOpt("-skip-startup-verify", strprintf(_("Skip checking the complete chain of work on startup (default: %u)"), DEFAULT_SKIPSTARTUPVERIFY));
 
     strUsage += HelpMessageGroup(_("Connection options:"));
     strUsage += HelpMessageOpt("-addnode=<ip>", _("Add a node to connect to and attempt to keep the connection open (see the `addnode` RPC command help for more info)"));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -263,6 +263,8 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
 {
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
+    const bool skipChainVerification = gArgs.GetBoolArg("-skip-startup-verify", DEFAULT_SKIPSTARTUPVERIFY);
+
     pcursor->Seek(std::make_pair(DB_BLOCK_INDEX, uint256()));
 
     // Load mapBlockIndex
@@ -287,8 +289,9 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 
-                if (!CheckProofOfWork(pindexNew->GetBlockPoWHash(), pindexNew->nBits, consensusParams))
-                    return error("%s: CheckProofOfWork failed: %s", __func__, pindexNew->ToString());
+                if (!skipChainVerification)
+                    if (!CheckProofOfWork(pindexNew->GetBlockPoWHash(), pindexNew->nBits, consensusParams))
+                        return error("%s: CheckProofOfWork failed: %s", __func__, pindexNew->ToString());
 
                 pcursor->Next();
             } else {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -38,6 +38,8 @@ static const int64_t nMaxBlockDBAndTxIndexCache = 1024;
 //! Max memory allocated to coin DB specific cache (MiB)
 static const int64_t nMaxCoinsDBCache = 8;
 
+static const bool DEFAULT_SKIPSTARTUPVERIFY = false;
+
 struct CDiskTxPos : public CDiskBlockPos
 {
     unsigned int nTxOffset; // after header


### PR DESCRIPTION
Starting up Vertcoin Core 0.12 is slow because of the full verification of the chain of work, #19. This PR adds a command-line switch that gives end-users the option to skip that verification. A temporary workaround for slow startup until we can optimize the actual checking (which is an important security measure).