### PR TITLE
Default startup verification only checks PoW from last checkpoint

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -364,6 +364,7 @@ std::string HelpMessage(HelpMessageMode mode)
 #endif
     strUsage += HelpMessageOpt("-txindex", strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"), DEFAULT_TXINDEX));
     strUsage += HelpMessageOpt("-skip-startup-verify", strprintf(_("Skip checking the complete chain of work on startup (default: %u)"), DEFAULT_SKIPSTARTUPVERIFY));
+    strUsage += HelpMessageOpt("-full-startup-verify", strprintf(_("Check the complete chain of work on startup from the Genesis block - otherwise check from the last checkpoint (default: %u)"), DEFAULT_FULLSTARTUPVERIFY));
 
     strUsage += HelpMessageGroup(_("Connection options:"));
     strUsage += HelpMessageOpt("-addnode=<ip>", _("Add a node to connect to and attempt to keep the connection open (see the `addnode` RPC command help for more info)"));

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -39,7 +39,7 @@ static const int64_t nMaxBlockDBAndTxIndexCache = 1024;
 static const int64_t nMaxCoinsDBCache = 8;
 
 static const bool DEFAULT_SKIPSTARTUPVERIFY = false;
-
+static const bool DEFAULT_FULLSTARTUPVERIFY = false;
 struct CDiskTxPos : public CDiskBlockPos
 {
     unsigned int nTxOffset; // after header


### PR DESCRIPTION
This PR will further improve the startup time (issue #19) by relying on checkpoints. By verifying the checkpoints, and only doing chain-of-work verification since the last checkpoint, the startup time is reduced by roughly 90%.

There's still a command-line switch (-full-startup-verify) to do the full verification from the Genesis block if desired. 