### PR TITLE
Fixes issue with DNS bootstrapping

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -125,13 +125,13 @@ public:
         assert(consensus.hashGenesisBlock == uint256S("0x4d96a915f49d40b1e5c2844d1ee2dccb90013a990ccea12c492d22110489f0c4"));
         assert(genesis.hashMerkleRoot == uint256S("0x4af38ca0e323c0a5226208a73b7589a52c030f234810cf51e13e3249fc0123e7"));
 
-        vSeeds.emplace_back("useast1.vtconline.org", true); // James Lovejoy
-        vSeeds.emplace_back("vtc.gertjaap.org", true); // Gert-Jaap Glasbergen
-        vSeeds.emplace_back("seed.vtc.bryangoodson.org", true); // Bryan Goodson
-        vSeeds.emplace_back("dnsseed.pknight.ca", true); // pknight
-        vSeeds.emplace_back("seed.orderofthetaco.org", true); // Eric (etang600)
-        vSeeds.emplace_back("seed.alexturek.org", true); // Alex Turek
-        vSeeds.emplace_back("vertcoin.mbl.cash", true); // jk_14
+        vSeeds.emplace_back("useast1.vtconline.org"); // James Lovejoy
+        vSeeds.emplace_back("vtc.gertjaap.org"); // Gert-Jaap Glasbergen
+        vSeeds.emplace_back("seed.vtc.bryangoodson.org"); // Bryan Goodson
+        vSeeds.emplace_back("dnsseed.pknight.ca"); // pknight
+        vSeeds.emplace_back("seed.orderofthetaco.org"); // Eric (etang600)
+        vSeeds.emplace_back("seed.alexturek.org"); // Alex Turek
+        vSeeds.emplace_back("vertcoin.mbl.cash"); // jk_14
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,71);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);
@@ -225,10 +225,10 @@ public:
         vFixedSeeds.clear();
         vSeeds.clear();
         // nodes with support for servicebits filtering should be at the top
-        vSeeds.emplace_back("jlovejoy.mit.edu", false);
-        vSeeds.emplace_back("gertjaap.ddns.net", false);
-        vSeeds.emplace_back("fr1.vtconline.org", false);
-        vSeeds.emplace_back("tvtc.vertcoin.org", false);
+        vSeeds.emplace_back("jlovejoy.mit.edu");
+        vSeeds.emplace_back("gertjaap.ddns.net");
+        vSeeds.emplace_back("fr1.vtconline.org");
+        vSeeds.emplace_back("tvtc.vertcoin.org");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,74);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);


### PR DESCRIPTION
This pull request fixes issue #42 

While debugging, i found that the hostnames the client was trying to bootstrap from were only the first character of the actual hostnames:

```
2018-05-08 12:00:13 Querying DNS Seed x9.u
2018-05-08 12:00:13 opencon thread start
2018-05-08 12:00:13 LookupHost returned false
2018-05-08 12:00:13 Querying DNS Seed x9.v
2018-05-08 12:00:13 LookupHost returned false
2018-05-08 12:00:13 Querying DNS Seed x9.s
2018-05-08 12:00:13 LookupHost returned false
2018-05-08 12:00:13 Querying DNS Seed x9.d
2018-05-08 12:00:13 LookupHost returned false
2018-05-08 12:00:13 Querying DNS Seed x9.s
2018-05-08 12:00:13 LookupHost returned false
2018-05-08 12:00:13 Querying DNS Seed x9.s
2018-05-08 12:00:13 LookupHost returned false
2018-05-08 12:00:13 Querying DNS Seed x9.v
2018-05-08 12:00:13 LookupHost returned false
2018-05-08 12:00:13 0 addresses found from DNS seeds
```
When comparing the lines where DNS seeds are added to Bitcoin core, they don't have the second parameter to `emplace_back` there. 

https://github.com/bitcoin/bitcoin/blob/master/src/chainparams.cpp#L132
https://github.com/vertcoin-project/vertcoin-core/blob/master/src/chainparams.cpp#L127

Upstream changed the vector type from CDNSSeedData to std::string and dynamically detects the support of service bit filtering, and falls back to adding it as oneshot node if it fails.

See: https://github.com/bitcoin/bitcoin/commit/6e89de5ba7ce706a9b6897eaf061e19319bc887f#diff-64cbe1ad5465e13bc59ee8bb6f3de2e7

The parameters to `emplace_back` being fed to the constructor of whatever type is in the vector, and `true` being `1` means it's passed as the `size_t n` parameter to the `string (const char* s, size_t n)` constructor. This explains the fact that the hostnames are cut off after the first character.

This PR should fix the issue with DNS bootstrapping