### PR TITLE
Fix #20 by changing bitcoin.conf to vertcoin.conf in the rpcuser python script

### DIFF
--- a/share/rpcauth/rpcauth.py
+++ b/share/rpcauth/rpcauth.py
@@ -36,6 +36,6 @@ if sys.version_info.major >= 3:
 m = hmac.new(bytearray(salt, 'utf-8'), bytearray(password, 'utf-8'), digestmod)
 result = m.hexdigest()
 
-print("String to be appended to bitcoin.conf:")
+print("String to be appended to vertcoin.conf:")
 print("rpcauth="+username+":"+salt+"$"+result)
 print("Your password:\n"+password)


### PR DESCRIPTION
A reference to the config file as `bitcoin.conf` was left behind in a Python script. Fixes #20.