### PR TITLE
Rename “OS X” to the newer “macOS” convention

### DIFF
--- a/contrib/init/README.md
+++ b/contrib/init/README.md
@@ -5,7 +5,7 @@ Upstart: bitcoind.conf
 OpenRC:  bitcoind.openrc
          bitcoind.openrcconf
 CentOS:  bitcoind.init
-OS X:    org.bitcoin.bitcoind.plist
+macOS:   org.bitcoin.bitcoind.plist
 ```
 have been made available to assist packagers in creating node packages here.
 


### PR DESCRIPTION
ping @metalicjames 

----

I renamed “OS X” to the newer “macOS” convention in `contrib/init/README.md`. ✏️ 

--[**Suriyaa Sundararuban**](https://suriyaa.tk/) <a href="https://github.com/SuriyaaKudoIsc"><img src="https://assets-cdn.github.com/images/icons/emoji/octocat.png" alt="GitHub Developer" width="18" height="18" /></a> <a href="https://vertcoin.org/team/"><img src="https://cdn.discordapp.com/emojis/430323443918176256.png" alt="Future Official Vertcoin Developer?" width="20" height="20" /></a> (***Donate some VTC:*** `vtc1qxvzg3syau59vrdmr498pdakz0y8w6vu8ynkwll`)