### PR TITLE
Update boost dependency to v1.69.0

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
 $(package)_version=1_64_0
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.64.0/source/
+$(package)_download_path=https://dl.bintray.com/boostorg/release/1.69.0/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
-$(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
+$(package)_sha256_hash=8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release


### PR DESCRIPTION
@metalicjames 

----

I **updated the version** of the `boost` dependency to `1.69.0` in `depends/packages/boost.mk`. ✏️ 

--[**Suriyaa Sundararuban**](https://suriyaa.tk/) <a href="https://github.com/SuriyaaKudoIsc"><img src="https://assets-cdn.github.com/images/icons/emoji/octocat.png" alt="GitHub Developer" width="18" height="18" /></a> <a href="https://vertcoin.org/team/"><img src="https://cdn.discordapp.com/emojis/430323443918176256.png" alt="Future Official Vertcoin Developer?" width="20" height="20" /></a> (***Donate some VTC:*** `vtc1qxvzg3syau59vrdmr498pdakz0y8w6vu8ynkwll`)