### PR TITLE
Multi-Algo - Defence against 51% attacks?

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -168,3 +168,15 @@ const CBlockIndex* LastCommonAncestor(const CBlockIndex* pa, const CBlockIndex* 
     assert(pa == pb);
     return pa;
 }
+
+const CBlockIndex* GetLastBlockIndexForAlgo(const CBlockIndex* pindex, int algo)
+{
+    for (;;)
+    {
+        if (!pindex)
+            return NULL;
+        if (pindex->GetAlgo() == algo)
+            return pindex;
+        pindex = pindex->pprev;
+    }
+}

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -264,12 +264,10 @@ arith_uint256 GetGeometricMeanPrevWork(const CBlockIndex& block)
 
 arith_uint256 GetBlockProof(const CBlockIndex& block)
 {
-    /** set changeover time to geometric mean work calculation in chainparams later */
-    // Consensus::Params params = Params().GetConsensus();
-    // int nHeight = block.nHeight;
+    Consensus::Params params = Params().GetConsensus();
+    int nHeight = block.nHeight;
 
-    // if(nHeight >= params.nMultiAlgoStart)
-    if(false)
+    if(nHeight > params.nStartMultiAlgoHash)
     {
         return GetGeometricMeanPrevWork(block);
     }

--- a/src/chain.h
+++ b/src/chain.h
@@ -294,9 +294,14 @@ public:
         return *phashBlock;
     }
 
-    uint256 GetBlockPoWHash() const 
+    uint256 GetBlockPoWHash() const
     {
         return GetBlockHeader().GetPoWHash(nHeight);
+    }
+
+    int GetAlgo() const
+    {
+        return ::GetAlgo(nVersion);
     }
 
     int64_t GetBlockTime() const
@@ -369,7 +374,8 @@ arith_uint256 GetBlockProof(const CBlockIndex& block);
 int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params&);
 /** Find the forking point between two chain tips. */
 const CBlockIndex* LastCommonAncestor(const CBlockIndex* pa, const CBlockIndex* pb);
-
+/** Return the index to the last block of algo */
+const CBlockIndex* GetLastBlockIndexForAlgo(const CBlockIndex* pindex, int algo);
 
 /** Used to marshal pointers into hashes for db storage. */
 class CDiskBlockIndex : public CBlockIndex

--- a/src/chain.h
+++ b/src/chain.h
@@ -294,9 +294,9 @@ public:
         return *phashBlock;
     }
 
-    uint256 GetBlockPoWHash() const
+    uint256 GetBlockPoWHash(const Consensus::Params& params) const
     {
-        return GetBlockHeader().GetPoWHash(nHeight);
+        return GetBlockHeader().GetPoWHash(nHeight, params);
     }
 
     int GetAlgo() const

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -109,6 +109,18 @@ public:
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x4b151d928c0aae106c9d69347df59e0088cbd33dd659deab126506865a8b0060"); //898726
 
+        consensus.nStartLyra2reHash = 208301; // height where lyra2re replaced scrypt-n
+        consensus.nStartLyra2re2Hash = 347000; // height where lyra2re2 replaced lyra2re
+        consensus.nStartLyra2re3Hash = 1080000; // height where lyra2re3 replaced lyra2re2
+        consensus.nStartMultiAlgoHash = 10000000; // height where multi-algorithm is active - UPDATE
+
+        consensus.nStartKGWWorkCalc = 26754; // height where KimotoGravityWell replaces bitcoin's difficulty algorithm
+
+        // multishield parameters
+        consensus.nAveragingInterval = 10; // 10 blocks
+        consensus.nMaxAdjustDown = 16; // 16% adjustment down
+        consensus.nMaxAdjustUp = 8; // 8% adjustment up
+
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -181,7 +193,7 @@ public:
         strNetworkID = "test";
         consensus.testnet = true;
         consensus.nSubsidyHalvingInterval = 840000;
-        consensus.BIP16Height = 0; 
+        consensus.BIP16Height = 0;
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 3.5 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 2.5 * 60;
@@ -193,23 +205,36 @@ public:
          // Deployment of BIP65, BIP66, and BIP34.
         consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].bit = 2;
         consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].nStartTime = 1486865123;
-        consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].nTimeout = 1517356801;    
+        consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].nTimeout = 1517356801;
 
         // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1486865123; 
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1517356801; 
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1486865123;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1517356801;
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1486865123;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1517356801; 
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1517356801;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000100010");
 
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x69ab56f74d75afa90b65b1fe10df8adaf2769e2ba64df1e1dc99c4d6717e1a2a"); //9000
+
+        consensus.nStartLyra2reHash = 0; // height where lyra2re replaced scrypt-n
+        consensus.nStartLyra2re2Hash = 0; // height where lyra2re2 replaced lyra2re
+        consensus.nStartLyra2re3Hash = 158220; // height where lyra2re3 replaced lyra2re2
+        consensus.nStartMultiAlgoHash = 210000; // height where multi-algorithm is active - UPDATE
+
+        consensus.nStartKGWWorkCalc = 2116; // height where KimotoGravityWell replaces bitcoin's difficulty algorithm
+
+        // multishield parameters
+        consensus.nAveragingInterval = 10; // 10 blocks
+        consensus.nMaxAdjustDown = 16; // 16% adjustment down
+        consensus.nMaxAdjustUp = 8; // 8% adjustment up
+        consensus.nLocalTargetAdjustment = 4; //target adjustment per algo
 
         pchMessageStart[0] = 'v';
         pchMessageStart[1] = 'e';

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -70,6 +70,16 @@ struct Params {
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;
     bool testnet;
+
+    int nStartLyra2reHash;
+    int nStartLyra2re2Hash;
+    int nStartLyra2re3Hash;
+    int nStartMultiAlgoHash;
+    int nStartKGWWorkCalc;
+    int nAveragingInterval;
+    int nMaxAdjustDown;
+    int nMaxAdjustUp;
+    int nLocalTargetAdjustment;
 };
 } // namespace Consensus
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1164,7 +1164,7 @@ bool AppInitParameterInteraction()
         miningAlgo = ALGO_LYRA2REV3;
     else if (strAlgo == "newalgo1")
         miningAlgo = ALGO_NEWALGO1;
-    else if (strAlgo == "newalgo1")
+    else if (strAlgo == "newalgo2")
         miningAlgo = ALGO_NEWALGO2;
     else
         miningAlgo = ALGO_LYRA2REV3;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -521,7 +521,7 @@ std::string LicenseInfo()
     const std::string URL_SOURCE_CODE = "<https://github.com/vertcoin-project/vertcoin-core>";
     const std::string URL_WEBSITE = "<https://vertcoin.org>";
 
-    return CopyrightHolders(strprintf(_("Copyright (C) %i-%i"), 2014, COPYRIGHT_YEAR) + " ", 
+    return CopyrightHolders(strprintf(_("Copyright (C) %i-%i"), 2014, COPYRIGHT_YEAR) + " ",
            strprintf(_("Copyright (C) %i-%i"), 2009, COPYRIGHT_YEAR) + " ") + "\n" +
            "\n" +
            strprintf(_("Please contribute if you find %s useful. "
@@ -1156,6 +1156,19 @@ bool AppInitParameterInteraction()
             }
         }
     }
+
+    // Set Mining Algorithm
+    std::string strAlgo = gArgs.GetArg("-algo", "lyra2rev3");
+    transform(strAlgo.begin(),strAlgo.end(),strAlgo.begin(),::tolower);
+    if (strAlgo == "lyra2rev3" || strAlgo == "lyra2re3" || strAlgo == "lyra2re")
+        miningAlgo = ALGO_LYRA2REV3;
+    else if (strAlgo == "newalgo1")
+        miningAlgo = ALGO_NEWALGO1;
+    else if (strAlgo == "newalgo1")
+        miningAlgo = ALGO_NEWALGO2;
+    else
+        miningAlgo = ALGO_LYRA2REV3;
+
     return true;
 }
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -156,7 +156,7 @@ public:
     BlockAssembler(const CChainParams& params, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
-    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx=true);
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, int algo, bool fMineWitnessTx=true);
 
 private:
     // utility functions

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -82,7 +82,7 @@ unsigned int GetNextWorkRequired_MultiShield(const CBlockIndex* pindexLast, cons
     return bnNew.GetCompact();
 }
 
-unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
+unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params, int algo)
 {
     static const int64_t        BlocksTargetSpacing  = 2.5 * 60; // 2.5 minutes
     unsigned int                TimeDaySeconds       = 60 * 60 * 24;
@@ -97,6 +97,9 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         if(nHeight < 2116) {
             return GetNextWorkRequired_Bitcoin(pindexLast, pblock, params);
         }
+
+        if(nHeight >= 250000)
+            return GetNextWorkRequired_MultiShield(pindexLast, params, algo);
 
         if(nHeight % 12 != 0) {
             CBigNum bnNew;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -19,7 +19,7 @@ unsigned int GetNextWorkRequired_MultiShield(const CBlockIndex* pindexLast, cons
     const int multiAlgoTargetSpacing = NUM_ALGOS*params.nPowTargetSpacing; //3*150 = 450 seconds per algo
     const int nAveragingTargetTimespan = params.nAveragingInterval * multiAlgoTargetSpacing; // 10*3*150
     const int nMinActualTimespan = nAveragingTargetTimespan * (100 - params.nMaxAdjustUp) / 100;
-    const int nMaxActualTimespan = nAveragingTargetTimespan * (100 - params.nMaxAdjustDown) / 100;
+    const int nMaxActualTimespan = nAveragingTargetTimespan * (100 + params.nMaxAdjustDown) / 100;
 
     // find first block in averaging interval
     // Go back by what we want to be nAveragingInterval blocks per algo

--- a/src/pow.h
+++ b/src/pow.h
@@ -16,7 +16,7 @@ class uint256;
 
 unsigned int GetNextWorkRequired_Bitcoin(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int KimotoGravityWell(const CBlockIndex* pindexLast, const CBlockHeader *pblock, uint64_t TargetBlocksSpacingSeconds, uint64_t PastBlocksMin, uint64_t PastBlocksMax, const Consensus::Params& params);
-unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
+unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&, int algo);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -19,7 +19,22 @@ uint256 CBlockHeader::GetHash() const
 uint256 CBlockHeader::GetPoWHash(const int nHeight) const
 {
    uint256 thash;
-   if((Params().NetworkIDString() == CBaseChainParams::TESTNET && nHeight > 158220) || nHeight > 1080000)
+   if((Params().NetworkIDString() == CBaseChainParams::TESTNET && nHeight > 250000) || nHeight > 2000000)
+   {
+       switch (GetAlgo())
+       {
+            case ALGO_LYRA2REV3:
+                lyra2re3_hash(BEGIN(nVersion), BEGIN(thash));
+                break;
+            case ALGO_NEWALGO1:
+                lyra2re3_hash(BEGIN(nVersion), BEGIN(thash));
+                break;
+            case ALGO_NEWALGO2:
+                lyra2re3_hash(BEGIN(nVersion), BEGIN(thash));
+                break;
+       }
+   }
+   else if((Params().NetworkIDString() == CBaseChainParams::TESTNET && nHeight > 158220) || nHeight > 1080000)
    {
         lyra2re3_hash(BEGIN(nVersion), BEGIN(thash));
    }
@@ -41,9 +56,10 @@ uint256 CBlockHeader::GetPoWHash(const int nHeight) const
 std::string CBlock::ToString() const
 {
     std::stringstream s;
-    s << strprintf("CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
+    s << strprintf("CBlock(hash=%s, ver=0x%08x, pow_algo=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
         GetHash().ToString(),
         nVersion,
+        GetAlgo(),
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),
         nTime, nBits, nNonce,
@@ -52,4 +68,38 @@ std::string CBlock::ToString() const
         s << "  " << tx->ToString() << "\n";
     }
     return s.str();
+}
+
+int GetAlgo(int nVersion)
+{
+    switch (nVersion & BLOCK_VERSION_ALGO)
+    {
+        case 0:
+            return ALGO_LYRA2REV3;
+            break;
+        case BLOCK_VERSION_NEWALGO1:
+            return ALGO_NEWALGO1;
+            break;
+        case BLOCK_VERSION_NEWALGO2:
+            return ALGO_NEWALGO2;
+            break;
+    }
+    return ALGO_LYRA2REV3;
+}
+
+std::string GetAlgoName(int algo)
+{
+    switch (algo)
+    {
+            case ALGO_LYRA2REV3:
+                return std::string("lyra2re3");
+                break;
+            case ALGO_NEWALGO1:
+                return std::string("newalgo1");
+                break;
+            case ALGO_NEWALGO2:
+                return std::string("newalgo2");
+                break;
+    }
+    return std::string("unknown");
 }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -9,9 +9,7 @@
 #include <primitives/transaction.h>
 #include <serialize.h>
 #include <uint256.h>
-
-#include <crypto/scrypt.h>
-#include <crypto/Lyra2RE/Lyra2RE.h>
+#include <consensus/params.h>
 
 /** Multi-Algo definitions used to encode algorithm in nVersion */
 
@@ -37,7 +35,7 @@ enum {
 int GetAlgo(int nVersion);
 
 /** return algorithm name */
-std::string GetAlgoName(int algo);
+std::string GetAlgoName(int nHeight, int algo, const Consensus::Params& params);
 
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work
@@ -91,7 +89,7 @@ public:
 
     uint256 GetHash() const;
 
-    uint256 GetPoWHash(const int nHeight) const;
+    uint256 GetPoWHash(const int nHeight, const Consensus::Params& params) const;
 
     int64_t GetBlockTime() const
     {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -13,6 +13,31 @@
 #include <crypto/scrypt.h>
 #include <crypto/Lyra2RE/Lyra2RE.h>
 
+/** Multi-Algo definitions used to encode algorithm in nVersion */
+
+enum {
+    ALGO_LYRA2REV3 = 0,
+    ALGO_NEWALGO1 = 1,
+    ALGO_NEWALGO2 = 2,
+    NUM_ALGOS_IMPL
+};
+
+const int NUM_ALGOS = 3;
+
+enum {
+    // primary version
+    BLOCK_VERSION_DEFAULT        = 4,
+    // algo
+    BLOCK_VERSION_ALGO      = (15 << 9),
+    BLOCK_VERSION_NEWALGO1  = (1 << 9),
+    BLOCK_VERSION_NEWALGO2  = (2 << 9),
+};
+
+/** extract algo from nVersion */
+int GetAlgo(int nVersion);
+
+/** return algorithm name */
+std::string GetAlgoName(int algo);
 
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work
@@ -71,6 +96,30 @@ public:
     int64_t GetBlockTime() const
     {
         return (int64_t)nTime;
+    }
+
+    /** Extract algo from blockheader */
+    inline int GetAlgo() const
+    {
+        return ::GetAlgo(nVersion);
+    }
+
+    /** Encode the algorithm into nVersion */
+    inline void SetAlgo(int algo)
+    {
+        switch(algo)
+        {
+            case ALGO_LYRA2REV3:
+                break;
+            case ALGO_NEWALGO1:
+                nVersion |= BLOCK_VERSION_NEWALGO1;
+                break;
+            case ALGO_NEWALGO2:
+                nVersion |= BLOCK_VERSION_NEWALGO2;
+                break;
+            default:
+                break;
+        }
     }
 };
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -51,19 +51,30 @@ extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& 
 /* Calculate the difficulty for a given block index,
  * or the block index of the given chain.
  */
-double GetDifficulty(const CChain& chain, const CBlockIndex* blockindex)
+double GetDifficulty(const CChain& chain, const CBlockIndex* blockindex, int algo)
 {
+    unsigned int nBits;
+    unsigned int powLimit = UintToArith256(Params().GetConsensus().powLimit).GetCompact();
+
     if (blockindex == nullptr)
     {
         if (chain.Tip() == nullptr)
-            return 1.0;
+            nBits = powLimit;
         else
-            blockindex = chain.Tip();
+        {
+            blockindex = GetLastBlockIndexForAlgo(chain.Tip(), algo);
+            if (blockindex == nullptr)
+                nBits = powLimit;
+            else
+                nBits = blockindex->nBits;
+        }
     }
+    else
+        nBits = blockindex->nBits;
 
-    int nShift = (blockindex->nBits >> 24) & 0xff;
+    int nShift = (nBits >> 24) & 0xff;
     double dDiff =
-        (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
+        (double)0x0000ffff / (double)(nBits & 0x00ffffff);
 
     while (nShift < 29)
     {
@@ -79,9 +90,9 @@ double GetDifficulty(const CChain& chain, const CBlockIndex* blockindex)
     return dDiff;
 }
 
-double GetDifficulty(const CBlockIndex* blockindex)
+double GetDifficulty(int algo, const CBlockIndex* blockindex)
 {
-    return GetDifficulty(chainActive, blockindex);
+    return GetDifficulty(chainActive, blockindex, algo);
 }
 
 UniValue blockheaderToJSON(const CBlockIndex* blockindex)
@@ -102,7 +113,9 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
     result.push_back(Pair("nonce", (uint64_t)blockindex->nNonce));
     result.push_back(Pair("bits", strprintf("%08x", blockindex->nBits)));
-    result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
+    result.push_back(Pair("pow_algo_id", blockindex->GetAlgo()));
+    result.push_back(Pair("pow_algo", GetAlgoName(blockindex->nHeight, blockindex->GetAlgo(), Params().GetConsensus())));
+    result.push_back(Pair("difficulty", GetDifficulty(blockindex->GetAlgo(), blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
 
     if (blockindex->pprev)
@@ -147,7 +160,10 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
     result.push_back(Pair("nonce", (uint64_t)block.nNonce));
     result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
-    result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
+    result.push_back(Pair("pow_algo_id", block.GetAlgo()));
+    result.push_back(Pair("pow_algo", GetAlgoName(blockindex->nHeight, block.GetAlgo(), Params().GetConsensus())));
+    result.push_back(Pair("pow_hash", block.GetPoWHash(blockindex->nHeight, Params().GetConsensus()).GetHex()));
+    result.push_back(Pair("difficulty", GetDifficulty(blockindex->GetAlgo(), blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
 
     if (blockindex->pprev)
@@ -353,7 +369,7 @@ UniValue getdifficulty(const JSONRPCRequest& request)
         );
 
     LOCK(cs_main);
-    return GetDifficulty();
+    return GetDifficulty(miningAlgo);
 }
 
 std::string EntryDescriptionString()
@@ -676,6 +692,8 @@ UniValue getblockheader(const JSONRPCRequest& request)
             "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"nonce\" : n,           (numeric) The nonce\n"
             "  \"bits\" : \"1d00ffff\", (string) The bits\n"
+            "  \"pow_algo_id\" : n,     (numeric) The algorithm id\n"
+            "  \"pow_algo\" : \"name\", (string) The algorithm name\n"
             "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
             "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
@@ -745,6 +763,9 @@ UniValue getblock(const JSONRPCRequest& request)
             "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"nonce\" : n,           (numeric) The nonce\n"
             "  \"bits\" : \"1d00ffff\", (string) The bits\n"
+            "  \"pow_algo_id\" : n,     (numeric) The algorithm id\n"
+            "  \"pow_algo\" : \"name\", (string) The algorithm name\n"
+            "  \"pow_hash\" : \"hash\"  (string) The proof-of-work hash\n"
             "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
             "  \"chainwork\" : \"xxxx\",  (string) Expected number of hashes required to produce the chain up to this block (in hex)\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
@@ -1128,6 +1149,9 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             "  \"headers\": xxxxxx,            (numeric) the current number of headers we have validated\n"
             "  \"bestblockhash\": \"...\",       (string) the hash of the currently best block\n"
             "  \"difficulty\": xxxxxx,         (numeric) the current difficulty\n"
+            "  \"difficulty_lyra2rev3\": xxxxxx,  (numeric) the current lyra2rev3 difficulty\n"
+            "  \"difficulty_newalgo1\": xxxxxx,   (numeric) the current newalgo1 difficulty\n"
+            "  \"difficulty_newalgo2\": xxxxxx,   (numeric) the current newalgo2 difficulty\n"
             "  \"mediantime\": xxxxxx,         (numeric) median time for the current best block\n"
             "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
             "  \"initialblockdownload\": xxxx, (bool) (debug information) estimate of whether this node is in Initial Block Download mode.\n"
@@ -1167,7 +1191,10 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     obj.push_back(Pair("blocks",                (int)chainActive.Height()));
     obj.push_back(Pair("headers",               pindexBestHeader ? pindexBestHeader->nHeight : -1));
     obj.push_back(Pair("bestblockhash",         chainActive.Tip()->GetBlockHash().GetHex()));
-    obj.push_back(Pair("difficulty",            (double)GetDifficulty()));
+    obj.push_back(Pair("difficulty",            (double)GetDifficulty(miningAlgo)));
+    obj.push_back(Pair("difficulty_lyra2rev3",  (double)GetDifficulty(ALGO_LYRA2REV3)));
+    obj.push_back(Pair("difficulty_newalgo1",   (double)GetDifficulty(ALGO_NEWALGO1)));
+    obj.push_back(Pair("difficulty_newalgo2",   (double)GetDifficulty(ALGO_NEWALGO2)));
     obj.push_back(Pair("mediantime",            (int64_t)chainActive.Tip()->GetMedianTimePast()));
     obj.push_back(Pair("verificationprogress",  GuessVerificationProgress(Params().TxData(), chainActive.Tip())));
     obj.push_back(Pair("initialblockdownload",  IsInitialBlockDownload()));
@@ -1517,7 +1544,7 @@ UniValue getchaintxstats(const JSONRPCRequest& request)
             pindex = chainActive.Tip();
         }
     }
-    
+
     assert(pindex != nullptr);
 
     if (request.params[0].isNull()) {

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -16,7 +16,7 @@ class UniValue;
  * @return A floating point number that is a multiple of the main net minimum
  * difficulty (4295032833 hashes).
  */
-double GetDifficulty(const CBlockIndex* blockindex = nullptr);
+double GetDifficulty(int algo, const CBlockIndex* blockindex = nullptr);
 
 /** Callback for when block tip changed. */
 void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -196,7 +196,12 @@ UniValue getmininginfo(const JSONRPCRequest& request)
             "  \"blocks\": nnn,             (numeric) The current block\n"
             "  \"currentblockweight\": nnn, (numeric) The last block weight\n"
             "  \"currentblocktx\": nnn,     (numeric) The last block transaction\n"
+            "  \"pow_algo_id\": n           (numeric) The active mining algorithm id\n"
+            "  \"pow_algo\": \"name\"       (string) The active mining algorithm name\n"
             "  \"difficulty\": xxx.xxxxx    (numeric) The current difficulty\n"
+            "  \"difficulty_lyra2rev3\": xxxxxx,  (numeric) the current lyra2rev3 difficulty\n"
+            "  \"difficulty_newalgo1\": xxxxxx,   (numeric) the current newalgo1 difficulty\n"
+            "  \"difficulty_newalgo2\": xxxxxx,   (numeric) the current newalgo2 difficulty\n"
             "  \"networkhashps\": nnn,      (numeric) The network hashes per second\n"
             "  \"pooledtx\": n              (numeric) The size of the mempool\n"
             "  \"chain\": \"xxxx\",           (string) current network name as defined in BIP70 (main, test, regtest)\n"
@@ -215,7 +220,12 @@ UniValue getmininginfo(const JSONRPCRequest& request)
     obj.push_back(Pair("blocks",           (int)chainActive.Height()));
     obj.push_back(Pair("currentblockweight", (uint64_t)nLastBlockWeight));
     obj.push_back(Pair("currentblocktx",   (uint64_t)nLastBlockTx));
-    obj.push_back(Pair("difficulty",       (double)GetDifficulty()));
+    obj.push_back(Pair("pow_algo_id",      (int)miningAlgo));
+    obj.push_back(Pair("pow_algo",         GetAlgoName(chainActive.Height(), miningAlgo, Params().GetConsensus())));
+    obj.push_back(Pair("difficulty",       (double)GetDifficulty(miningAlgo)));
+    obj.push_back(Pair("difficulty_lyra2rev3",       (double)GetDifficulty(ALGO_LYRA2REV3)));
+    obj.push_back(Pair("difficulty_newalgo1",       (double)GetDifficulty(ALGO_NEWALGO1)));
+    obj.push_back(Pair("difficulty_newalgo2",       (double)GetDifficulty(ALGO_NEWALGO2)));
     obj.push_back(Pair("networkhashps",    getnetworkhashps(request)));
     obj.push_back(Pair("pooledtx",         (uint64_t)mempool.size()));
     obj.push_back(Pair("chain",            Params().NetworkIDString()));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -118,7 +118,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd)
     {
-        std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(Params()).CreateNewBlock(coinbaseScript->reserveScript));
+        std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(Params()).CreateNewBlock(coinbaseScript->reserveScript, miningAlgo));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -126,7 +126,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             LOCK(cs_main);
             IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
         }
-        while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetPoWHash(nHeight+1), pblock->nBits, Params().GetConsensus())) {
+        while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetPoWHash(nHeight+1, Params().GetConsensus()), pblock->nBits, Params().GetConsensus())) {
             ++pblock->nNonce;
             --nMaxTries;
         }
@@ -523,7 +523,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
 
         // Create new block
         CScript scriptDummy = CScript() << OP_TRUE;
-        pblocktemplate = BlockAssembler(Params()).CreateNewBlock(scriptDummy, fSupportsSegwit);
+        pblocktemplate = BlockAssembler(Params()).CreateNewBlock(scriptDummy, miningAlgo, fSupportsSegwit);
         if (!pblocktemplate)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -48,7 +48,7 @@ void TestDifficulty(uint32_t nbits, double expected_difficulty)
      */
     CChain chain;
 
-    double difficulty = GetDifficulty(chain, block_index);
+    double difficulty = GetDifficulty(chain, block_index, ALGO_LYRA2REV3);
     delete block_index;
 
     RejectDifficultyMismatch(difficulty, expected_difficulty);
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(get_difficulty_for_very_high_target)
 BOOST_AUTO_TEST_CASE(get_difficulty_for_null_tip)
 {
     CChain chain;
-    double difficulty = GetDifficulty(chain, nullptr);
+    double difficulty = GetDifficulty(chain, nullptr, ALGO_LYRA2REV3);
     RejectDifficultyMismatch(difficulty, 1.0);
 }
 
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(get_difficulty_for_null_block_index)
 {
     CChain chain = CreateChainWithNbits(0x1df88f6f);
 
-    double difficulty = GetDifficulty(chain, nullptr);
+    double difficulty = GetDifficulty(chain, nullptr, ALGO_LYRA2REV3);
     delete chain.Tip();
 
     double expected_difficulty = 0.004023;
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(get_difficulty_for_block_index_overrides_tip)
      */
     CBlockIndex* override_block_index = CreateBlockIndexWithNbits(0x12345678);
 
-    double difficulty = GetDifficulty(chain, override_block_index);
+    double difficulty = GetDifficulty(chain, override_block_index, ALGO_LYRA2REV3);
     delete chain.Tip();
     delete override_block_index;
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -129,7 +129,7 @@ void TestPackageSelection(const CChainParams& chainparams, CScript scriptPubKey,
     uint256 hashHighFeeTx = tx.GetHash();
     mempool.addUnchecked(hashHighFeeTx, entry.Fee(50000).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
 
-    std::unique_ptr<CBlockTemplate> pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3);
     BOOST_CHECK(pblocktemplate->block.vtx[1]->GetHash() == hashParentTx);
     BOOST_CHECK(pblocktemplate->block.vtx[2]->GetHash() == hashHighFeeTx);
     BOOST_CHECK(pblocktemplate->block.vtx[3]->GetHash() == hashMediumFeeTx);
@@ -149,7 +149,7 @@ void TestPackageSelection(const CChainParams& chainparams, CScript scriptPubKey,
     tx.vout[0].nValue = 5000000000LL - 1000 - 50000 - feeToUse;
     uint256 hashLowFeeTx = tx.GetHash();
     mempool.addUnchecked(hashLowFeeTx, entry.Fee(feeToUse).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3);
     // Verify that the free tx and the low fee tx didn't get selected
     for (size_t i=0; i<pblocktemplate->block.vtx.size(); ++i) {
         BOOST_CHECK(pblocktemplate->block.vtx[i]->GetHash() != hashFreeTx);
@@ -163,7 +163,7 @@ void TestPackageSelection(const CChainParams& chainparams, CScript scriptPubKey,
     tx.vout[0].nValue -= 2; // Now we should be just over the min relay fee
     hashLowFeeTx = tx.GetHash();
     mempool.addUnchecked(hashLowFeeTx, entry.Fee(feeToUse+2).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3);
     BOOST_CHECK(pblocktemplate->block.vtx[4]->GetHash() == hashFreeTx);
     BOOST_CHECK(pblocktemplate->block.vtx[5]->GetHash() == hashLowFeeTx);
 
@@ -184,7 +184,7 @@ void TestPackageSelection(const CChainParams& chainparams, CScript scriptPubKey,
     tx.vout[0].nValue = 5000000000LL - 100000000 - feeToUse;
     uint256 hashLowFeeTx2 = tx.GetHash();
     mempool.addUnchecked(hashLowFeeTx2, entry.Fee(feeToUse).SpendsCoinbase(false).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3);
 
     // Verify that this tx isn't selected.
     for (size_t i=0; i<pblocktemplate->block.vtx.size(); ++i) {
@@ -197,7 +197,7 @@ void TestPackageSelection(const CChainParams& chainparams, CScript scriptPubKey,
     tx.vin[0].prevout.n = 1;
     tx.vout[0].nValue = 100000000 - 10000; // 10k satoshi fee
     mempool.addUnchecked(tx.GetHash(), entry.Fee(10000).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3);
     BOOST_CHECK(pblocktemplate->block.vtx[8]->GetHash() == hashLowFeeTx2);
 }
 
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     fCheckpointsEnabled = false;
 
     // Simple block creation, nothing special yet:
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3));
 
     // We can't make transactions until we have inputs
     // Therefore, load 100 blocks :)
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     LOCK(cs_main);
 
     // Just to make sure we can still make simple blocks
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3));
 
     const CAmount BLOCKSUBSIDY = 50*COIN;
     const CAmount LOWFEE = CENT;
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         tx.vin[0].prevout.hash = hash;
     }
 
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-blk-sigops"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3), std::runtime_error, HasReason("bad-blk-sigops"));
     mempool.clear();
 
     tx.vin[0].prevout.hash = txFirst[0]->GetHash();
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(spendsCoinbase).SigOpsCost(80).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3));
     mempool.clear();
 
     // block size > limit
@@ -314,13 +314,13 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(spendsCoinbase).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3));
     mempool.clear();
 
     // orphan in mempool, template creation fails
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).FromTx(tx));
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
     mempool.clear();
 
     // child with higher feerate than parent
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].nValue = tx.vout[0].nValue+BLOCKSUBSIDY-HIGHERFEE; //First txn output + fresh coinbase - new txn fee
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(HIGHERFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3));
     mempool.clear();
 
     // coinbase in mempool, template creation fails
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // give it a fee so it'll get mined
     mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
     // Should throw bad-cb-multiple
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-cb-multiple"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3), std::runtime_error, HasReason("bad-cb-multiple"));
     mempool.clear();
 
     // double spend txn pair in mempool, template creation fails
@@ -362,7 +362,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].scriptPubKey = CScript() << OP_2;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(HIGHFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
     mempool.clear();
 
     // subsidy changing
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->BuildSkip();
         chainActive.SetTip(next);
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3));
     // Extend to a 210000-long block chain.
     while (chainActive.Tip()->nHeight < 210000) {
         CBlockIndex* prev = chainActive.Tip();
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->BuildSkip();
         chainActive.SetTip(next);
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3));
 
     // invalid p2sh txn in mempool, template creation fails
     tx.vin[0].prevout.hash = txFirst[0]->GetHash();
@@ -407,7 +407,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
     // Should throw block-validation-failed
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("block-validation-failed"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3), std::runtime_error, HasReason("block-validation-failed"));
     mempool.clear();
 
     // Delete the dummy blocks again.
@@ -495,7 +495,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vin[0].nSequence = CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG | 1;
     BOOST_CHECK(!TestSequenceLocks(tx, flags)); // Sequence locks fail
 
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3));
 
     // None of the of the absolute height/time locked tx should have made
     // it into the template because we still check IsFinalTx in CreateNewBlock,
@@ -508,7 +508,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     chainActive.Tip()->nHeight++;
     SetMockTime(chainActive.Tip()->GetMedianTimePast() + 1);
 
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 5);
 
     chainActive.Tip()->nHeight--;

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -134,7 +134,7 @@ CBlock
 TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey)
 {
     const CChainParams& chainparams = Params();
-    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey, ALGO_LYRA2REV3);
     CBlock& block = pblocktemplate->block;
 
     // Replace mempool-selected txns with just coinbase plus passed-in txns:

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -54,7 +54,7 @@ struct CoinEntry {
 
 }
 
-CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, true) 
+CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, true)
 {
 }
 
@@ -295,7 +295,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nTx            = diskindex.nTx;
 
                 MapCheckpoints::iterator it = checkPoints.find(pindexNew->nHeight);
-                if(it != checkPoints.end()) 
+                if(it != checkPoints.end())
                 {
                     LogPrintf("Verifying checkpoint at height %i\n", pindexNew->nHeight);
                     if(pindexNew->GetBlockHash() != it->second)
@@ -307,7 +307,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                     if(fullChainVerification || pindexNew->nHeight > highestCheckpointHeight)
                     {
                         if(pindexNew->nHeight % 10000 == 0) LogPrintf("Checking PoW for block %i\n", pindexNew->nHeight);
-                        if (!CheckProofOfWork(pindexNew->GetBlockPoWHash(), pindexNew->nBits, consensusParams))
+                        if (!CheckProofOfWork(pindexNew->GetBlockPoWHash(consensusParams), pindexNew->nBits, consensusParams))
                             return error("%s: CheckProofOfWork failed: %s\n", __func__, pindexNew->ToString());
                     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -95,6 +95,7 @@ bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
 bool fLogIPs = DEFAULT_LOGIPS;
 std::atomic<bool> fReopenDebugLog(false);
 CTranslationInterface translationInterface;
+int miningAlgo = 0;
 
 /** Log categories bitfield. */
 std::atomic<uint32_t> logCategories(0);

--- a/src/util.h
+++ b/src/util.h
@@ -54,6 +54,7 @@ extern bool fLogTimeMicros;
 extern bool fLogIPs;
 extern std::atomic<bool> fReopenDebugLog;
 extern CTranslationInterface translationInterface;
+extern int miningAlgo;
 
 extern const char * const BITCOIN_CONF_FILENAME;
 extern const char * const BITCOIN_PID_FILENAME;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -351,7 +351,7 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp, bool 
 
     CBlockIndex* tip = chainActive.Tip();
     assert(tip != nullptr);
-    
+
     CBlockIndex index;
     index.pprev = tip;
     // CheckSequenceLocks() uses chainActive.Height()+1 to evaluate
@@ -3085,7 +3085,8 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
 
     // Check proof of work
     const Consensus::Params& consensusParams = params.GetConsensus();
-    if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
+    int algo = block.GetAlgo();
+    if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams, algo))
         return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
 
     // Check against checkpoints
@@ -3144,7 +3145,7 @@ static bool ContextualCheckBlock(const CBlock& block, CValidationState& state, c
     }
 
     // Enforce rule that the coinbase starts with serialized block height
-    if(VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_NVERSIONBIPS, versionbitscache) == THRESHOLD_ACTIVE) 
+    if(VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_NVERSIONBIPS, versionbitscache) == THRESHOLD_ACTIVE)
     {
         CScript expect = CScript() << nHeight;
         if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||


### PR DESCRIPTION
What's here is the foundation for migrating VTC to a multi-algo coin. History has shown this to be far more resilient to 51% attacks than a traditional single PoW algorithm.

What needs more time, attention, and discussion:

1. Number of PoW algorithms. Currently 3, however 5 is a common choice for multi-algo. Need to balance between diluting hashrate across a larger set of choices vs complexity of launching an attack
1. Choice of algorithms. I would continue with Lyra2rev3 (until ASICs are confirmed), other choices may include something like x21s. I believe a good balance would be something for each of NVidia and AMD miners. Possibility of including a CPU only algorithm?
1. Difficulty adjustment algorithm and parameters. Currently coded with DGB's Multishield, however in testing I am not satisfied with it. I prefer Myriadcoin's method, where each PoW algorithm in completely independent of one another.
1. Hardfork timing.
1. Choice of bits in nVersion to encode algorithm. Could be changed to higher bits, freeing up low-bit numbers for versionbits
