### PR TITLE
Ban nodes that keep requesting the same headers

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2261,8 +2261,8 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         if(nLimit <= 0) {
             if (pindex == nodestate->pindexBestHeaderSent) {
                 bDuplicate = true;
-            } else {
-                if (nodestate->pindexBestHeaderSent->GetAncestor(pindex->nHeight) == pindex) {
+            } else if (nodestate->pindexBestHeaderSent) {
+                if (pindex && nodestate->pindexBestHeaderSent->GetAncestor(pindex->nHeight) == pindex) {
                     bDuplicate = true;
                 }
             }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2260,9 +2260,11 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         bool bDuplicate = false;
         if(nLimit <= 0) {
             if (pindex == nodestate->pindexBestHeaderSent) {
+                 LogPrint(BCLog::NET, "getheaders already sent peer=%d\n", pfrom->GetId());
                 bDuplicate = true;
             } else if (nodestate->pindexBestHeaderSent) {
-                if (pindex && nodestate->pindexBestHeaderSent->GetAncestor(pindex->nHeight) == pindex) {
+                if (pindex && (nodestate->pindexBestHeaderSent->GetAncestor(pindex->nHeight) == pindex)) {
+                    LogPrint(BCLog::NET, "getheaders before best index sent from peer=%d\n", pfrom->GetId());
                     bDuplicate = true;
                 }
             }
@@ -2273,11 +2275,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             if(nodestate->nDuplicateHeaderRequests >= 3) {
                 Misbehaving(pfrom->GetId(), (nodestate->nDuplicateHeaderRequests-2) * 10, "Duplicate header requests");
             }
-        } 
-        else 
-        {
-            // Reset the duplicate header request count to zero when it's not duplicate.
-            nodestate->nDuplicateHeaderRequests = 0;
         }
 
 


### PR DESCRIPTION
Pre-Lyra2REv3 nodes are still active and keep requesting blocks that do have a common ancestor to our chain - and thus we keep sending them leading to huge amounts of data being transferred in vain. 

The earlier assumption was that older nodes will eventually disconnect (ban) nodes that keep giving them invalid headers. But it seems that 0.11 nodes are not doing this, and therefore causing a huge amount of data traffic by continuously requesting the same headers that they then don't accept (because they have an invalid proof of work)

We should prevent sending duplicate header chunks over and over. This PR makes Vertcoin Core keep track of the amount of duplicate header requests, and increases the ban score of a node when it requests the same set of headers 3 times or more.

Under normal operation, this would not happen since a node would not ask for the same headers - and even if it would (at the tip) there would never be more than 2000 headers in the result set since it is either not that far behind, or saved the response we gave them the first time and are now asking for other headers.

I have made a binary of this and am running it on my own node which has served over 450GB of pointless headers to 0.11 nodes over the past few months. I will track its results and report this in this thread.