### PR TITLE
Add DNS Tracker/Seeder for domain:  'dnsseed.vertcoin.cc'

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -113,6 +113,7 @@ public:
         vSeeds.emplace_back("useast1.vtconline.org"); // James Lovejoy
         vSeeds.emplace_back("vtc.gertjaap.org"); // Gert-Jaap Glasbergen 
         vSeeds.emplace_back("vert.idzstad.pl"); // Jaroslaw (jk_14)
+        vSeeds.emplace_back("dnsseed.vertcoin.cc"); // DB Keys
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,71);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);


### PR DESCRIPTION
Running DNS Tracker/Seeder to serve host IP's for sub-domain name '**dnsseed.vertcoin.cc**'
(sub-domain dnsseed.vertcoinc.cc is name-served by vtc.chainetics.com)

Verify operation with:   

~$ dig dnsseed.vertcoin.cc A

; <<>> DiG 9.10.3-P4-Ubuntu <<>> dnsseed.vertcoin.cc A
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 955
;; flags: qr rd ra; QUERY: 1, ANSWER: 25, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;dnsseed.vertcoin.cc.		IN	A

;; ANSWER SECTION:
dnsseed.vertcoin.cc.	3600	IN	A	209.6.50.76
dnsseed.vertcoin.cc.	3600	IN	A	159.203.9.152
dnsseed.vertcoin.cc.	3600	IN	A	91.155.56.15
dnsseed.vertcoin.cc.	3600	IN	A	188.42.46.2
dnsseed.vertcoin.cc.	3600	IN	A	88.107.127.27
dnsseed.vertcoin.cc.	3600	IN	A	83.221.211.116
dnsseed.vertcoin.cc.	3600	IN	A	95.216.23.211
dnsseed.vertcoin.cc.	3600	IN	A	80.211.243.155
dnsseed.vertcoin.cc.	3600	IN	A	80.65.23.139
dnsseed.vertcoin.cc.	3600	IN	A	5.196.74.100
dnsseed.vertcoin.cc.	3600	IN	A	207.180.206.143
dnsseed.vertcoin.cc.	3600	IN	A	136.55.40.183
dnsseed.vertcoin.cc.	3600	IN	A	72.186.250.228
dnsseed.vertcoin.cc.	3600	IN	A	47.151.11.28
dnsseed.vertcoin.cc.	3600	IN	A	23.28.126.225
dnsseed.vertcoin.cc.	3600	IN	A	98.115.159.208
dnsseed.vertcoin.cc.	3600	IN	A	94.113.65.40
dnsseed.vertcoin.cc.	3600	IN	A	24.230.104.33
dnsseed.vertcoin.cc.	3600	IN	A	5.188.104.245
dnsseed.vertcoin.cc.	3600	IN	A	145.239.0.126
dnsseed.vertcoin.cc.	3600	IN	A	178.238.224.213
dnsseed.vertcoin.cc.	3600	IN	A	79.97.195.187
dnsseed.vertcoin.cc.	3600	IN	A	93.123.65.11
dnsseed.vertcoin.cc.	3600	IN	A	185.250.205.205
dnsseed.vertcoin.cc.	3600	IN	A	2.83.38.14

;; Query time: 1619 msec
;; SERVER: 139.162.69.5#53(139.162.69.5)
;; WHEN: Wed Dec 30 13:54:01 UTC 2020
;; MSG SIZE  rcvd: 448


