### PR TITLE
Revert min fee defaults to pre-0.16.0 values

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -50,7 +50,7 @@ struct PrecomputedTransactionData;
 struct LockPoints;
 
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
-static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
+static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 100000;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */
 static const unsigned int DEFAULT_ANCESTOR_LIMIT = 25;
 /** Default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -66,7 +66,7 @@ WalletCreationStatus CreateWallet(interfaces::Chain& chain, const SecureString& 
 //! -paytxfee default
 constexpr CAmount DEFAULT_PAY_TX_FEE = 0;
 //! -fallbackfee default
-static const CAmount DEFAULT_FALLBACK_FEE = 0;
+static const CAmount DEFAULT_FALLBACK_FEE = 100000;
 //! -discardfee default
 static const CAmount DEFAULT_DISCARD_FEE = 10000;
 //! -mintxfee default


### PR DESCRIPTION
The default value was changed to 0 as part of the re-base to upstream 0.20.1. This value is insufficient to have your TX relayed when smart fee calculation is unavailable or a fee-rate is not set manually.

Edit: I'm not sure if we need fe1395e if we revert the default minrelaytxfee, I'll test it both ways.