### PR TITLE
Build using Guix

### DIFF
--- a/contrib/gitian-descriptors/assign_DISTNAME
+++ b/contrib/gitian-descriptors/assign_DISTNAME
@@ -9,4 +9,4 @@ if RECENT_TAG="$(git describe --exact-match HEAD)"; then
 else
     VERSION="$(git rev-parse --short=12 HEAD)"
 fi
-DISTNAME="bitcoin-${VERSION}"
+DISTNAME="vertcoin-${VERSION}"

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -1,6 +1,6 @@
-# Bootstrappable Bitcoin Core Builds
+# Bootstrappable Vertcoin Core Builds
 
-This directory contains the files necessary to perform bootstrappable Bitcoin
+This directory contains the files necessary to perform bootstrappable Vertcoin
 Core builds.
 
 [Bootstrappability][b17e] furthers our binary security guarantees by allowing us
@@ -14,7 +14,7 @@ We achieve bootstrappability by using Guix as a functional package manager.
 Conservatively, a x86_64 machine with:
 
 - 4GB of free disk space on the partition that /gnu/store will reside in
-- 24GB of free disk space on the partition that the Bitcoin Core git repository
+- 24GB of free disk space on the partition that the Vertcoin Core git repository
   resides in
 
 > Note: these requirements are slightly less onerous than those of Gitian builds
@@ -84,7 +84,7 @@ export PATH="${HOME}/.config/guix/current/bin${PATH:+:}$PATH"
 
 ### As a Development Environment
 
-For a Bitcoin Core depends development environment, simply invoke
+For a Vertcoin Core depends development environment, simply invoke
 
 ```sh
 guix environment --manifest=contrib/guix/manifest.scm
@@ -95,7 +95,7 @@ a `depends` build injected into your environment.
 
 ### As a Tool for Deterministic Builds
 
-From the top of a clean Bitcoin Core repository:
+From the top of a clean Vertcoin Core repository:
 
 ```sh
 ./contrib/guix/guix-build.sh
@@ -192,7 +192,7 @@ This can be overridden for all `guix` invocations by passing the
 overridden on a call-by-call basis by passing the same `--substitute-urls`
 option to client tools such at `guix environment`.
 
-To use dongcarl's substitute server for Bitcoin Core builds after having
+To use dongcarl's substitute server for Vertcoin Core builds after having
 [authorized his signing key](#authorize-the-signing-keys):
 
 ```

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -38,7 +38,7 @@ and untracked files and directories will be wiped, allowing you to start anew.
 EOF
 }
 
-# Deterministically build Bitcoin Core for HOSTs (overridable by environment)
+# Deterministically build Vertcoin Core for HOSTs (overridable by environment)
 # shellcheck disable=SC2153
 for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu x86_64-w64-mingw32}; do
 
@@ -104,7 +104,7 @@ for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv
                                  --container \
                                  --pure \
                                  --no-cwd \
-                                 --share="$PWD"=/bitcoin \
+                                 --share="$PWD"=/vertcoin \
                                  --expose="$(git rev-parse --git-common-dir)" \
                                  ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
                                  ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
@@ -113,7 +113,7 @@ for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv
                                         SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
                                         ${V:+V=1} \
                                         ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
-                                      bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"
+                                      bash -c "cd /vertcoin && bash contrib/guix/libexec/build.sh"
     )
 
 done

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -169,6 +169,7 @@ fi
 CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-tests"
 case "$HOST" in
     *linux*) CONFIGFLAGS+=" --enable-glibc-back-compat" ;;
+    *mingw*) CONFIGFLAGS+=" --disable-shared" ;;
 esac
 
 # CFLAGS

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -174,7 +174,7 @@ esac
 # CFLAGS
 HOST_CFLAGS="-O2 -g"
 case "$HOST" in
-    *linux*)  HOST_CFLAGS+=" -ffile-prefix-map=${PWD}=." ;;
+    *linux*)  HOST_CFLAGS+=" -ffile-prefix-map=${PWD}=. -fPIC" ;;
     *mingw*)  HOST_CFLAGS+=" -fno-ident" ;;
 esac
 

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -244,11 +244,11 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
     (
         cd installed
 
-        case "$HOST" in
-            *mingw*)
-                mv --target-directory="$DISTNAME"/lib/ "$DISTNAME"/bin/*.dll
-                ;;
-        esac
+#        case "$HOST" in
+#            *mingw*)
+#                mv --target-directory="$DISTNAME"/lib/ "$DISTNAME"/bin/*.dll
+#                ;;
+#        esac
 
         # Prune libtool and object archives
         find . -name "lib*.la" -delete

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -27,7 +27,7 @@ BASEPREFIX="${PWD}/depends"
 OUTDIR="${OUTDIR:-${PWD}/output}"
 [ -e "$OUTDIR" ] || mkdir -p "$OUTDIR"
 
-# Setup the directory where our Bitcoin Core build for HOST will occur
+# Setup the directory where our Vertcoin Core build for HOST will occur
 DISTSRC="${DISTSRC:-${PWD}/distsrc-${HOST}}"
 if [ -e "$DISTSRC" ]; then
     echo "DISTSRC directory '${DISTSRC}' exists, probably because of previous builds... Aborting..."
@@ -211,7 +211,7 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
 
     sed -i.old 's/-lstdc++ //g' config.status libtool src/univalue/config.status src/univalue/libtool
 
-    # Build Bitcoin Core
+    # Build Vertcoin Core
     make --jobs="$MAX_JOBS" ${V:+V=1}
 
     # Perform basic ELF security checks on a series of executables.
@@ -232,12 +232,12 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
             ;;
     esac
 
-    # Setup the directory where our Bitcoin Core build for HOST will be
+    # Setup the directory where our Vertcoin Core build for HOST will be
     # installed. This directory will also later serve as the input for our
     # binary tarballs.
     INSTALLPATH="${PWD}/installed/${DISTNAME}"
     mkdir -p "${INSTALLPATH}"
-    # Install built Bitcoin Core to $INSTALLPATH
+    # Install built Vertcoin Core to $INSTALLPATH
     make install DESTDIR="${INSTALLPATH}" ${V:+V=1}
 
     (

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -166,7 +166,7 @@ fi
 ###########################
 
 # CONFIGFLAGS
-CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
+CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-tests"
 case "$HOST" in
     *linux*) CONFIGFLAGS+=" --enable-glibc-back-compat" ;;
 esac

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -14,7 +14,7 @@ SetDateSave off
 !define URL @PACKAGE_URL@
 
 # MUI Symbol Definitions
-!define MUI_ICON "@abs_top_srcdir@/share/pixmaps/bitcoin.ico"
+!define MUI_ICON "@abs_top_srcdir@/share/pixmaps/vertcoin.ico"
 !define MUI_WELCOMEFINISHPAGE_BITMAP "@abs_top_srcdir@/share/pixmaps/nsis-wizard.bmp"
 !define MUI_HEADERIMAGE
 !define MUI_HEADERIMAGE_RIGHT
@@ -51,7 +51,7 @@ Var StartMenuGroup
 !insertmacro MUI_LANGUAGE English
 
 # Installer attributes
-InstallDir $PROGRAMFILES64\Bitcoin
+InstallDir $PROGRAMFILES64\Vertcoin
 CRCCheck on
 XPStyle on
 BrandingText " "
@@ -104,7 +104,7 @@ Section -post SEC0001
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
     WriteRegStr HKCR "@PACKAGE_TARNAME@" "URL Protocol" ""
-    WriteRegStr HKCR "@PACKAGE_TARNAME@" "" "URL:Bitcoin"
+    WriteRegStr HKCR "@PACKAGE_TARNAME@" "" "URL:Vertcoin"
     WriteRegStr HKCR "@PACKAGE_TARNAME@\DefaultIcon" "" $INSTDIR\@BITCOIN_GUI_NAME@@EXEEXT@
     WriteRegStr HKCR "@PACKAGE_TARNAME@\shell\open\command" "" '"$INSTDIR\@BITCOIN_GUI_NAME@@EXEEXT@" "%1"'
 SectionEnd
@@ -137,7 +137,7 @@ Section -un.post UNSEC0001
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\Uninstall $(^Name).lnk"
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\$(^Name).lnk"
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\@PACKAGE_NAME@ (testnet, 64-bit).lnk"
-    Delete /REBOOTOK "$SMSTARTUP\Bitcoin.lnk"
+    Delete /REBOOTOK "$SMSTARTUP\Vertcoin.lnk"
     Delete /REBOOTOK $INSTDIR\uninstall.exe
     Delete /REBOOTOK $INSTDIR\debug.log
     Delete /REBOOTOK $INSTDIR\db.log


### PR DESCRIPTION
This PR enables bootstrappable Vertcoin-Core builds using [Guix](https://github.com/vertcoin-project/vertcoin-core/tree/master/contrib/guix) for the following [hosts](https://github.com/vertcoin-project/vertcoin-core/blob/master/contrib/guix/guix-build.sh#L43).

Those wishing to provide attestations, please checkout this PR and add checksums as a comment.

Issues https://github.com/vertcoin-project/vertcoin-core/issues/166 and https://github.com/vertcoin-project/vertcoin-core/issues/165 are being mitigated by passing extra compilation flags.