### PR TITLE
codesigning: windows script

### DIFF
--- a/contrib/guix/sign.sh
+++ b/contrib/guix/sign.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+VERSION="$(git rev-parse --short=12 HEAD)"
+
+cd output
+
+KEY_FILE=${KEY_FILE:-~/codesigning/vertcoin-project.p12}
+if [[ ! -f "$KEY_FILE" ]]; then
+    ls $KEY_FILE
+    echo "Make sure that $KEY_FILE exists"
+fi
+
+if ! which osslsigncode > /dev/null 2>&1; then
+    echo "Please install osslsigncode"
+fi
+
+rm -rf signed
+mkdir -p signed >/dev/null 2>&1
+
+unzip vertcoin-$VERSION-win64.zip -d signed
+cd signed/vertcoin-$VERSION/bin
+
+echo "Found $(ls *.exe | wc -w) files to sign."
+for f in $(ls *.exe); do
+    echo "Signing $f..."
+    osslsigncode sign \
+      -h sha256 \
+      -pkcs12 "$KEY_FILE" \
+      -pass "$VERTCOIN_PROJECT_KEY_PASSWORD" \
+      -n "Vertcoin-Core" \
+      -i "https://vertcoin.org/" \
+      -t "http://timestamp.digicert.com/" \
+      -in "$f" \
+      -out "../../$f"
+    ls ../../$f -lah
+done
+
+cd ../..
+rm vertcoin-$VERSION/bin/*
+mv vertcoin*.exe vertcoin-$VERSION/bin
+zip -r vertcoin-$VERSION-win64.zip vertcoin-$VERSION
+rm -r vertcoin-$VERSION
+
+echo "Signing vertcoin-$VERSION-win64-setup..."
+osslsigncode sign \
+  -h sha256 \
+  -pkcs12 "$KEY_FILE" \
+  -pass "$VERTCOIN_PROJECT_KEY_PASSWORD" \
+  -n "Vertcoin-Core" \
+  -i "https://vertcoin.org/" \
+  -t "http://timestamp.digicert.com/" \
+  -in "../vertcoin-$VERSION-win64-setup-unsigned.exe" \
+  -out "vertcoin-$VERSION-win64-setup.exe"


### PR DESCRIPTION
This script expects the windows codesigning certificate to be in `~/codesigning/vertcoin-project.p12` and `VERTCOIN_PROJECT_KEY_PASSWORD` to be stored as an environment variable.  

Only those that have been given the code signing certificate will be able to use this.  The next major release will allow anyone to build and verify the codesigned output by using a detached-sig created by the codesigner.

```
$ HOSTS="x86_64-w64-mingw32" ./contrib/guix/guix-build.sh`
$ ./contrib/guix/sign.sh`
$ find output/ -type f -print0 | sort -z | xargs -r0 sha256sum
cb83752602582012248ba775ac49375d1b3d04e5bd3290116cba8566682d1be1  output/signed/vertcoin-f8fff8d0498f-win64-setup.exe
aeb9fbda49b4ae7790f3b89cc8f714280b72123dcf9d2bffc6cd247274ded6c3  output/signed/vertcoin-f8fff8d0498f-win64.zip
4f639e795ae387e7cdd7298992dfd4edd524f9909d48c096e57478aead2599c7  output/src/vertcoin-f8fff8d0498f.tar.gz
083e657125f5515ce181ce5ebc2cbd38e93a6d518ae67bdc3c362015e020d92f  output/vertcoin-f8fff8d0498f-win64-debug.zip
d1b5d4ae0be997baffcf30c269452e70267e29d020b73ee1d2c4346ea029829b  output/vertcoin-f8fff8d0498f-win64-setup-unsigned.exe
256361cc1e5c5ca5733580114261b7b6936ae0073fd8475fc8f2fa6f7afa115e  output/vertcoin-f8fff8d0498f-win64.zip
ee7ecc449ecfd1e2b070fce097a05225b8f5dc57c92084514a1e67f0ea9926e0  output/vertcoin-f8fff8d0498f-win-unsigned.tar.gz
```