### PR TITLE
args: remove -skip-startup-verify option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -492,7 +492,6 @@ void SetupServerArgs(NodeContext& node)
 
     argsman.AddArg("-verthash-diskonly", "Don't load Verthash's datafile into RAM. Will slow down validation significantly, but might be needed on low-memory systems.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 
-    argsman.AddArg("-skip-startup-verify", "Skip checking the chain of work on startup from the last checkpoint", ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);
     argsman.AddArg("-full-startup-verify", "Check the complete chain of work on startup from the Genesis block", ArgsManager::ALLOW_BOOL, OptionsCategory::OPTIONS);
 
     g_wallet_init_interface.AddWalletOptions(argsman);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -247,7 +247,6 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
 {
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
-    const bool skipChainVerification = gArgs.GetBoolArg("-skip-startup-verify", false);
     const bool fullChainVerification = gArgs.GetBoolArg("-full-startup-verify", false);
 
     const CChainParams& chainparams = Params();
@@ -285,13 +284,12 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                     if(pindexNew->GetBlockHash() != it->second)
                         return error("%s: Block hash mismatches checkpoint: %s\n", __func__, pindexNew->ToString());
                 }
-                if (!skipChainVerification)
-                    if(fullChainVerification || pindexNew->nHeight > highestCheckpointHeight)
-                    {
-                        if(pindexNew->nHeight % 10000 == 0) LogPrintf("Checking PoW for block %i\n", pindexNew->nHeight);
-                        if (!CheckProofOfWork(pindexNew->GetBlockPoWHash(), pindexNew->nBits, consensusParams))
-                            return error("%s: CheckProofOfWork failed: %s\n", __func__, pindexNew->ToString());
-                    }
+                if(fullChainVerification || pindexNew->nHeight > highestCheckpointHeight)
+                {
+                    if(pindexNew->nHeight % 10000 == 0) LogPrintf("Checking PoW for block %i\n", pindexNew->nHeight);
+                    if (!CheckProofOfWork(pindexNew->GetBlockPoWHash(), pindexNew->nBits, consensusParams))
+                        return error("%s: CheckProofOfWork failed: %s\n", __func__, pindexNew->ToString());
+                }
                 pcursor->Next();
             } else {
                 return error("%s: failed to read value", __func__);


### PR DESCRIPTION
The startup verification process of checking proof of work takes a very long time, especially when the last checkpoint is well in the past.  Since we are always verifying checkpoints, I think that this extra step of checking proof of work by default is unnecessary.  This PR keeps the `-full-startup-verify` flag to give users a choice when they want to enable this feature.