### PR TITLE
Change from boost to STL for filesystem calls

### DIFF
--- a/src/crypto/verthash.cpp
+++ b/src/crypto/verthash.cpp
@@ -6,7 +6,7 @@
 #include <ctime>
 #include <iomanip>
 #include <sstream>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #define HEADER_SIZE 80
 #define HASH_OUT_SIZE 32
@@ -30,7 +30,7 @@ bool Verthash::VerifyDatFile()
     CSHA256 ctx;
     if(!datFileInRam) {
         fs::path dataFile = gArgs.GetDataDirNet() / "verthash.dat";
-        if(!boost::filesystem::exists(dataFile)) {
+        if(!fs::exists(dataFile)) {
             throw std::runtime_error("Verthash datafile not found");
         }
         FILE* datfile = fsbridge::fopen(dataFile.c_str(),"rb");
@@ -57,7 +57,7 @@ bool Verthash::VerifyDatFile()
 
 void Verthash::LoadInRam() {
     fs::path dataFile = gArgs.GetDataDirNet() / "verthash.dat";
-    if(!boost::filesystem::exists(dataFile)) {
+    if(!fs::exists(dataFile)) {
         throw std::runtime_error("Verthash datafile not found");
     }
     FILE* datfile = fsbridge::fopen(dataFile.c_str(),"rb");
@@ -107,7 +107,7 @@ void Verthash::Hash(const char* input, char* output)
 
     if(!datFileInRam) {
         fs::path dataFile = gArgs.GetDataDirNet() / "verthash.dat";
-        if(!boost::filesystem::exists(dataFile)) {
+        if(!fs::exists(dataFile)) {
             throw std::runtime_error("Verthash datafile not found");
         }
         VerthashDatFile = fsbridge::fopen(dataFile.c_str(),"rb");

--- a/src/crypto/verthash_datfile.cpp
+++ b/src/crypto/verthash_datfile.cpp
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-
+#include <filesystem>
 
 #define NODE_SIZE 32
 
@@ -460,8 +460,8 @@ RecursiveMutex VerthashDatFile::cs_Datfile;
 
 void VerthashDatFile::DeleteMiningDataFile() {
     const fs::path targetFile = gArgs.GetDataDirNet() / "verthash.dat";
-    if(boost::filesystem::exists(targetFile)) {
-        boost::filesystem::remove(targetFile);
+    if(fs::exists(targetFile)) {
+        fs::remove(targetFile);
     }
 }
 
@@ -474,7 +474,7 @@ void VerthashDatFile::CreateMiningDataFile() {
     }
 
     const fs::path targetFile = gArgs.GetDataDirNet() / "verthash.dat";
-    if(!boost::filesystem::exists(targetFile)) {
+    if(!fs::exists(targetFile)) {
         LogPrintf("Starting Proof-of-Space datafile generation at %s.\n", targetFile.string());
 
         const char *hashInput = "Verthash Proof-of-Space Datafile";


### PR DESCRIPTION
Now that we're compiling with c++17, move away from Boost libraries to STL for filesystem calls specific to Verthash