### PR TITLE
Reduce getheaders spam by serializing getheaders requests per peer

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2983,7 +2983,9 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, SOCKET hSocketIn, const
       m_conn_type(conn_type_in),
       nLocalServices(nLocalServicesIn)
 {
-    if (inbound_onion) assert(conn_type_in == ConnectionType::INBOUND);
+    nPendingHeaderRequests = 0;
+	
+	if (inbound_onion) assert(conn_type_in == ConnectionType::INBOUND);
     hSocket = hSocketIn;
     addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
     if (conn_type_in != ConnectionType::BLOCK_RELAY) {

--- a/src/net.h
+++ b/src/net.h
@@ -554,7 +554,10 @@ public:
         std::chrono::microseconds m_next_send_feefilter{0};
     };
 
-    // m_tx_relay == nullptr if we're not relaying transactions with this peer
+	// Counts getheaders requests sent to this peer
+    std::atomic<int64_t> nPendingHeaderRequests;
+    
+	// m_tx_relay == nullptr if we're not relaying transactions with this peer
     std::unique_ptr<TxRelay> m_tx_relay;
 
     /** UNIX epoch time of the last block received from this peer that we had

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -297,6 +297,7 @@ public:
     void Misbehaving(const NodeId pnode, const int howmuch, const std::string& message) override;
     void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv,
                         const std::chrono::microseconds time_received, const std::atomic<bool>& interruptMsgProc) override;
+	void RequestHeadersFrom(CNode& pto, CConnman& connman, const CBlockIndex* pindex, uint256 untilHash, bool fforceQuery);
 
 private:
     void _RelayTransaction(const uint256& txid, const uint256& wtxid)
@@ -1047,6 +1048,26 @@ void PeerManagerImpl::FindNextBlocksToDownload(NodeId nodeid, unsigned int count
 }
 
 } // namespace
+
+// Do not request headers from a peer we are
+// already requesting headers from, unless forced.
+void PeerManagerImpl::RequestHeadersFrom(CNode& pto, CConnman& connman, const CBlockIndex* pindex, uint256 untilHash, bool fforceQuery)
+{
+  if (pto.nPendingHeaderRequests > 0) {
+    if (fforceQuery) {
+      LogPrint(BCLog::NET, "forcing getheaders request (%d) to peer=%d (%d open)\n",
+                pindex->nHeight, pto.GetId(), pto.nPendingHeaderRequests);
+    } else {
+      LogPrint(BCLog::NET, "dropped getheaders request (%d) to peer=%d\n", pindex->nHeight, pto.GetId());
+      return;
+    }
+  }
+  const CNetMsgMaker msgMaker(pto.GetCommonVersion());
+  LogPrint(BCLog::NET, "getheaders request (%d) to peer=%d (%d open)\n", pindex->nHeight, pto.GetId(), pto.nPendingHeaderRequests);
+  connman.PushMessage(&pto, msgMaker.Make(NetMsgType::GETHEADERS, m_chainman.ActiveChain().GetLocator(pindex), untilHash));
+  pto.nPendingHeaderRequests += 1;
+
+}
 
 void PeerManagerImpl::PushNodeVersion(CNode& pnode, int64_t nTime)
 {
@@ -2029,7 +2050,8 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, const Peer& peer,
         //   nUnconnectingHeaders gets reset back to 0.
         if (!m_chainman.m_blockman.LookupBlockIndex(headers[0].hashPrevBlock) && nCount < MAX_BLOCKS_TO_ANNOUNCE) {
             nodestate->nUnconnectingHeaders++;
-            m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::GETHEADERS, m_chainman.ActiveChain().GetLocator(pindexBestHeader), uint256()));
+       		// Allow a single getheaders query before triggering DoS
+            RequestHeadersFrom(pfrom, m_connman, pindexBestHeader, uint256(), true);
             LogPrint(BCLog::NET, "received header %s: missing prev block %s, sending getheaders (%d) to end (peer=%d, nUnconnectingHeaders=%d)\n",
                     headers[0].GetHash().ToString(),
                     headers[0].hashPrevBlock.ToString(),
@@ -2093,9 +2115,13 @@ void PeerManagerImpl::ProcessHeadersMessage(CNode& pfrom, const Peer& peer,
             // Headers message had its maximum size; the peer may have more headers.
             // TODO: optimize: if pindexLast is an ancestor of m_chainman.ActiveChain().Tip or pindexBestHeader, continue
             // from there instead.
+			//
+			// Do not allow multiple getheader queries in parallel at
+            // this point - makes sure that any parallel queries will end here,
+            // preventing "getheaders" spam.
             LogPrint(BCLog::NET, "more getheaders (%d) to end to peer=%d (startheight:%d)\n",
                                  pindexLast->nHeight, pfrom.GetId(), peer.m_starting_height);
-            m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::GETHEADERS, m_chainman.ActiveChain().GetLocator(pindexLast), uint256()));
+            RequestHeadersFrom(pfrom, m_connman, pindexLast, uint256(), false);
         }
 
         // If this set of headers is valid and ends in a block with at least as
@@ -2942,7 +2968,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         }
 
         if (best_block != nullptr) {
-            m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::GETHEADERS, m_chainman.ActiveChain().GetLocator(pindexBestHeader), *best_block));
+			// We force this check, in case we're only connected to nodes that send invs
+			RequestHeadersFrom(pfrom, m_connman, pindexBestHeader, *best_block, true);
             LogPrint(BCLog::NET, "getheaders (%d) %s to peer=%d\n", pindexBestHeader->nHeight, best_block->ToString(), pfrom.GetId());
         }
 
@@ -3417,8 +3444,9 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         if (!m_chainman.m_blockman.LookupBlockIndex(cmpctblock.header.hashPrevBlock)) {
             // Doesn't connect (or is genesis), instead of DoSing in AcceptBlockHeader, request deeper headers
-            if (!m_chainman.ActiveChainstate().IsInitialBlockDownload())
-                m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::GETHEADERS, m_chainman.ActiveChain().GetLocator(pindexBestHeader), uint256()));
+            if (!m_chainman.ActiveChainstate().IsInitialBlockDownload()) {
+				RequestHeadersFrom(pfrom, m_connman, pindexBestHeader, uint256(), true);
+			}
             return;
         }
 
@@ -3700,7 +3728,11 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         std::vector<CBlockHeader> headers;
 
-        // Bypass the normal CBlock deserialization, as we don't want to risk deserializing 2000 full blocks.
+        if (pfrom.nPendingHeaderRequests > 0) {
+          pfrom.nPendingHeaderRequests -= 1;
+	    }
+		
+		// Bypass the normal CBlock deserialization, as we don't want to risk deserializing 2000 full blocks.
         unsigned int nCount = ReadCompactSize(vRecv);
         if (nCount > MAX_HEADERS_RESULTS) {
             Misbehaving(pfrom.GetId(), 20, strprintf("headers message size = %u", nCount));
@@ -4523,10 +4555,14 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                    the peer's known best block.  This wouldn't be possible
                    if we requested starting at pindexBestHeader and
                    got back an empty response.  */
+
+				   // Make sure that if we are already processing an inv
+				   // or header message from this peer caused by a new block being
+                   // mined at chaintip, we do not send another getheaders request
                 if (pindexStart->pprev)
                     pindexStart = pindexStart->pprev;
                 LogPrint(BCLog::NET, "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight, pto->GetId(), peer->m_starting_height);
-                m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::GETHEADERS, m_chainman.ActiveChain().GetLocator(pindexStart), uint256()));
+				RequestHeadersFrom(*pto, m_connman, pindexStart, uint256(), false);
             }
         }
 


### PR DESCRIPTION
This is gracefully borrowed from:
https://github.com/dogecoin/dogecoin/pull/2417

Introduces a counter for getheader requests that have been sent to a peer but are pending response, reducing the number of parallel requests a node pushes out to its peers when needing to sync large amounts of headers. All getheader requests are serialized during initial sync, except when a non-connecting header is received, allowing the node to resolve issues with peers sending faulty blocks using the DoS mechanism, and when we get an inv for a block that we do not know, because it's possible we're only connected to legacy nodes that do not implement header announcement properly.