### PR TITLE
builder-keys: additional links and information

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -25,7 +25,7 @@ test/lint/lint-all.sh
 
 if [ "$CIRRUS_REPO_FULL_NAME" = "bitcoin/bitcoin" ] && [ -n "$CIRRUS_CRON" ]; then
     git log --merges --before="2 days ago" -1 --format='%H' > ./contrib/verify-commits/trusted-sha512-root-commit
-    ${CI_RETRY_EXE}  gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $(<contrib/verify-commits/trusted-keys) &&
+    ${CI_RETRY_EXE}  gpg --keyserver hkps://keys.openpgp.org --recv-keys $(<contrib/verify-commits/trusted-keys) &&
     ./contrib/verify-commits/verify-commits.py --clean-merge=2;
 fi
 

--- a/contrib/builder-keys/README.md
+++ b/contrib/builder-keys/README.md
@@ -19,8 +19,14 @@ gpg --refresh-keys
 To fetch keys of builders and active developers, feed the list of fingerprints
 of the primary keys into gpg:
 
+On \*NIX:
 ```sh
 while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ./keys.txt
+```
+
+On Windows (requires Gpg4win >= 4.0.0):
+```
+FOR /F "tokens=1" %i IN (keys.txt) DO gpg --keyserver hkps://keys.openpgp.org --recv-keys %i
 ```
 
 Add your key to the list if you provided Guix attestations for two major or

--- a/contrib/builder-keys/README.md
+++ b/contrib/builder-keys/README.md
@@ -20,7 +20,7 @@ To fetch keys of builders and active developers, feed the list of fingerprints
 of the primary keys into gpg:
 
 ```sh
-while read fingerprint keyholder_name; do gpg --keyserver hkp://keys.openpgp.org --recv-keys ${fingerprint}; done < ./keys.txt
+while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ./keys.txt
 ```
 
 Add your key to the list if you provided Guix attestations for two major or

--- a/contrib/verify-commits/README.md
+++ b/contrib/verify-commits/README.md
@@ -40,7 +40,7 @@ Import trusted keys
 In order to check the commit signatures, you must add the trusted PGP keys to your machine. [GnuPG](https://gnupg.org/) may be used to import the trusted keys by running the following command:
 
 ```sh
-gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $(<contrib/verify-commits/trusted-keys)
+gpg --keyserver hkps://keys.openpgp.org --recv-keys $(<contrib/verify-commits/trusted-keys)
 ```
 
 Key expiry/revocation


### PR DESCRIPTION
Cherry-picks two commits from upstream related to builder-keys. The first gives context for the switch to using keys.openpgp.org as keyserver and includes links that were missed by https://github.com/vertcoin-project/vertcoin-core/pull/213. The second includes helpful instructions for Windows to import and verify builder keys.