### PR TITLE
update nMinimumChainWork, defaultAssumeValid, chainTxData

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -96,8 +96,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1628899200; // August 14, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 1623304; // Approximately September 1, 2021
 
-        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000ea23677f4c4103d3e");
-        consensus.defaultAssumeValid = uint256S("0x3a9d0a6b19f4c20959caef1bad1a7aa18e492c049327ccaf3b3fcf7c3815f4e0"); //1740000
+        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000ea486815b14b61400");
+        consensus.defaultAssumeValid = uint256S("0x8d45b551b45904d28ba69dc7112ff7793e5f229d9f1eb10bd105afbca9c4b783"); //2046000
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -162,10 +162,10 @@ public:
         };
 
         chainTxData = ChainTxData{
-            // Data from rpc: getchaintxstats 16384 3a9d0a6b19f4c20959caef1bad1a7aa18e492c049327ccaf3b3fcf7c3815f4e0
-            1648016191, // nTime
-            4991331,  // nTxCount
-            0.01460440502969592 // dTxRate
+            // Data from rpc: getchaintxstats 16384 8d45b551b45904d28ba69dc7112ff7793e5f229d9f1eb10bd105afbca9c4b783
+            1694046637, // nTime
+            5566381,  // nTxCount
+            0.01130516952117601 // dTxRate
         };
     }
 };
@@ -210,8 +210,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1630713600; // September 4, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
-        consensus.nMinimumChainWork = uint256S("00000000000000000000000000000000000000000000000000016f5327d0f0d9");
-        consensus.defaultAssumeValid = uint256S("0xe437f50bb18b6aebbefcceb10fc9f9f21fedbe6c4150420c9c1a30144b6310b3"); // 480000
+        consensus.nMinimumChainWork = uint256S("00000000000000000000000000000000000000000000000000016f80e95b3727");
+        consensus.defaultAssumeValid = uint256S("0x584306547f33e3cdeab59d49e13d7ad863b9b54b8e5c5b0dc4c1863ed710a881"); // 700000
 
         pchMessageStart[0] = 'v';
         pchMessageStart[1] = 'e';
@@ -260,10 +260,10 @@ public:
         };
 
         chainTxData = ChainTxData{
-            // Data from RPC: getchaintxstats 17280 e437f50bb18b6aebbefcceb10fc9f9f21fedbe6c4150420c9c1a30144b6310b3
-            /* nTime    */ 1652742448,
-            /* nTxCount */ 486681,
-            /* dTxRate  */ 0.006649445321588033,
+            // Data from RPC: getchaintxstats 16384 584306547f33e3cdeab59d49e13d7ad863b9b54b8e5c5b0dc4c1863ed710a881
+            /* nTime    */ 1688217334,
+            /* nTxCount */ 706731,
+            /* dTxRate  */ 0.006687625362362025,
         };
     }
 };


### PR DESCRIPTION
Update chain parameters for upcoming major release. See [doc/release-process.md](https://github.com/vertcoin-project/vertcoin-core/blob/23.x/doc/release-process.md) for review instructions.

`m_assumed_blockchain_size` and `m_assumed_chain_state_size` has no change

Mainnet 
`chainTxData`:

```
vertcoin-cli getchaintxstats 16384 8d45b551b45904d28ba69dc7112ff7793e5f229d9f1eb10bd105afbca9c4b783
{
  "time": 1694046637,
  "txcount": 5566381,
  "window_final_block_hash": "8d45b551b45904d28ba69dc7112ff7793e5f229d9f1eb10bd105afbca9c4b783",
  "window_final_block_height": 2046000,
  "window_block_count": 16384,
  "window_tx_count": 28079,
  "window_interval": 2483731,
  "txrate": 0.01130516952117601
}
```
`nMinimumChainWork`, `defaultAssumeValid`:
```
vertcoin-cli getblockheader 8d45b551b45904d28ba69dc7112ff7793e5f229d9f1eb10bd105afbca9c4b783
{
  "hash": "8d45b551b45904d28ba69dc7112ff7793e5f229d9f1eb10bd105afbca9c4b783",
  "confirmations": 2306,
  "height": 2046000,
  "version": 536870912,
  "versionHex": "20000000",
  "merkleroot": "67d563dfe8d8a0466071f2e3adc6d87876afcbfa4644d98578a3838c9a19f8cd",
  "time": 1694046637,
  "mediantime": 1694046171,
  "nonce": 1288606976,
  "bits": "1c036ef3",
  "difficulty": 74.5606214807276,
  "chainwork": "00000000000000000000000000000000000000000000000ea486815b14b61400",
  "nTx": 1,
  "previousblockhash": "8de78bce904b3443d3c8227722c40149ced0c8522e1072df3d6f08f4d088b2c6",
  "nextblockhash": "8dc5672f011dd23e6123b87d65e14cabc48c4c8d1703603857be875664e5d55e"
}
```
Testnet
```
vertcoin-cli --testnet getchaintxstats 16384 584306547f33e3cdeab59d49e13d7ad863b9b54b8e5c5b0dc4c1863ed710a881
{
  "time": 1688217334,
  "txcount": 706731,
  "window_final_block_hash": "584306547f33e3cdeab59d49e13d7ad863b9b54b8e5c5b0dc4c1863ed710a881",
  "window_final_block_height": 700000,
  "window_block_count": 16384,
  "window_tx_count": 16384,
  "window_interval": 2449898,
  "txrate": 0.006687625362362025
}
```
```
vertcoin-cli --testnet getblockheader 584306547f33e3cdeab59d49e13d7ad863b9b54b8e5c5b0dc4c1863ed710a881
{
  "hash": "584306547f33e3cdeab59d49e13d7ad863b9b54b8e5c5b0dc4c1863ed710a881",
  "confirmations": 33731,
  "height": 700000,
  "version": 536870912,
  "versionHex": "20000000",
  "merkleroot": "91dc14580a2a2d286b388a71d746056886d289e2bdfbfc8b96dc8be896049778",
  "time": 1688217334,
  "mediantime": 1688216001,
  "nonce": 5194,
  "bits": "1e110849",
  "difficulty": 0.0002293392990083612,
  "chainwork": "00000000000000000000000000000000000000000000000000016f80e95b3727",
  "nTx": 1,
  "previousblockhash": "eb76654a21e9473b8dc51ccc04ed1bd551d0bc4fc2db3859eef97a792969553a",
  "nextblockhash": "95e6fb8111d8398d914d7710815c5da564391b9ce8d1ef293b8cad47d4410040"
}
```