### PR TITLE
24.x-rebase: HasValidProofOfWork updates for Vertcoin Core

### DIFF
--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -127,6 +127,9 @@ public:
     /** Return the amount of work in the chain received during the PRESYNC phase. */
     arith_uint256 GetPresyncWork() const { return m_current_chain_work; }
 
+    /** Return the height reached during the REDOWNLOAD phase */
+    int64_t GetRedownloadHeight() const { return m_redownload_buffer_last_height; }
+
     /** Construct a HeadersSyncState object representing a headers sync via this
      *  download-twice mechanism).
      *

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -75,6 +75,8 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
 // or decrease beyond the permitted limits.
 bool PermittedDifficultyTransition(const Consensus::Params& params, int64_t height, uint32_t old_nbits, uint32_t new_nbits)
 {
+// Vertcoin uses KGW for network retargetting
+/*
     if (params.fPowAllowMinDifficultyBlocks) return true;
 
     if (height % params.DifficultyAdjustmentInterval() == 0) {
@@ -118,7 +120,8 @@ bool PermittedDifficultyTransition(const Consensus::Params& params, int64_t heig
         if (minimum_new_target > observed_new_target) return false;
     } else if (old_nbits != new_nbits) {
         return false;
-    }
+    } */
+    //Vertcoin uses KGW for network retargetting
     return true;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3432,10 +3432,11 @@ std::vector<unsigned char> ChainstateManager::GenerateCoinbaseCommitment(CBlock&
     return commitment;
 }
 
-bool HasValidProofOfWork(const std::vector<CBlockHeader>& headers, const Consensus::Params& consensusParams)
+bool HasValidProofOfWork(const std::vector<CBlockHeader>& headers, const Consensus::Params& consensusParams, int nHeight)
 {
+    int preSyncHeight = nHeight + 1;
     return std::all_of(headers.cbegin(), headers.cend(),
-            [&](const auto& header) { return CheckProofOfWork(header.GetHash(), header.nBits, consensusParams);});
+            [&](const auto& header) { return CheckProofOfWork(header.GetPoWHash(preSyncHeight++), header.nBits, consensusParams);});
 }
 
 arith_uint256 CalculateHeadersWork(const std::vector<CBlockHeader>& headers)

--- a/src/validation.h
+++ b/src/validation.h
@@ -341,7 +341,7 @@ bool TestBlockValidity(BlockValidationState& state,
                        bool fCheckMerkleRoot = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Check with the proof of work on each blockheader matches the value in nBits */
-bool HasValidProofOfWork(const std::vector<CBlockHeader>& headers, const Consensus::Params& consensusParams);
+bool HasValidProofOfWork(const std::vector<CBlockHeader>& headers, const Consensus::Params& consensusParams, int nHeight);
 
 /** Return the sum of the work on a given set of headers */
 arith_uint256 CalculateHeadersWork(const std::vector<CBlockHeader>& headers);


### PR DESCRIPTION
This PR updates Vertcoin Core to support the new multi-pass pre-sync header process in Bitcoin Core 24.x+.  